### PR TITLE
Avoid E2EE on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <h1>Family Travel Booking <span class="accent">Made Simple</span></h1>
     <p>
       Organize your family's frequent flyer numbers, Known Traveler details, and loyalty programs in one secure place.
-      Skip the scattered notes and spreadsheets, and never miss earning a frequent flyer mile. <strong>End‑to‑end encrypted through iCloud — your data stays private.</strong>
+      Skip the scattered notes and spreadsheets, and never miss earning a frequent flyer mile. <strong>Fully encrypted through iCloud — your data stays private.</strong>
     </p>
     <p>
 
@@ -94,14 +94,19 @@
   <section id="privacy">
     <h2>Your Data Stays 🔒&nbsp;<span class="accent security">Completely Private</span></h2>
     <p>
-      Perkfolio uses iCloud with end‑to‑end encryption. Only your devices can access your data.
+      Perkfolio uses iCloud with strong encryption.
+      Only your devices can access your data.
     </p>
 
     <ul class="cards">
       <li>
         <span class="jumbomoji">🔐</span>
-        <h3>End-to-End Encrypted</h3>
-        <p>All data is encrypted through iCloud with Apple's industry-leading security. Even we can't see your information.</p>
+        <h3>Fully Encrypted</h3>
+        <p>
+          All data is encrypted through iCloud with Apple's industry-leading security.
+          Even we can't see your information.
+          Data is End-to-End Encrypted with Advanced Data Protection.
+        </p>
       </li>
       <li>
         <span class="jumbomoji">🚫</span>


### PR DESCRIPTION
CloudKit encrypted fields are only truly E2EE if the user has ADP enabled, so this adjusts some of the wording to be more accurate in the common case of it _not_ being enabled.